### PR TITLE
Update liveness probe timeout

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -109,10 +109,12 @@ spec:
           httpGet:
             path: /docs
             port: http
+          timeoutSeconds: 10
         readinessProbe:
           httpGet:
             path: /docs
             port: http
+          timeoutSeconds: 10
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:


### PR DESCRIPTION
The default 1s is too short for start the app.

Signed-off-by: Wayne Sun <gsun@redhat.com>