### PR TITLE
Set pvc accessMode as ReadWriteOnce

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -38,7 +38,7 @@ persistence:
   enabled: true
   subPath:
   existingClaim:
-  accessMode: ReadWriteMany
+  accessMode: ReadWriteOnce
   size: 1G
   storageClass:
   VolumeName:


### PR DESCRIPTION
As by default scaling is diabled and ReadWriteOnce volume is more
available.

Signed-off-by: Wayne Sun <gsun@redhat.com>