### PR TITLE
Direct call join and send message after connection

### DIFF
--- a/app/api/endpoints/irc.py
+++ b/app/api/endpoints/irc.py
@@ -32,6 +32,6 @@ async def send_message(
     except OSError as err:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"{err}")
+            detail=f"{err}. Please check IRC config is right and server:port is accessible.")
 
     return {"msg": "Message have been sent"}


### PR DESCRIPTION
The dispatcher on events is not working under coroutine, so direct
call join and send message after connection.

Also s/ensure_future/create_task/g as create_task is latest
preferred way.

Signed-off-by: Wayne Sun <gsun@redhat.com>