### PR TITLE
Add servers in openapi schema

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -6,6 +6,7 @@ from pydantic import AnyHttpUrl, BaseSettings, EmailStr, HttpUrl, validator, Red
 
 
 class Settings(BaseSettings):
+    DOMAIN: str
     API_V1_STR: str = "/api/v1"
     SECRET_KEY: str = secrets.token_urlsafe(32)
     # 60 minutes * 24 hours * 8 days = 8 days

--- a/app/main.py
+++ b/app/main.py
@@ -42,6 +42,16 @@ def custom_openapi():
     openapi_schema["info"]["x-logo"] = {
         "url": "https://raw.githubusercontent.com/waynesun09/notify-service/main/docs/static/notify-logo.png"
     }
+
+    # Set servers in the schema
+    server = {}
+    # TODO: Fix hard code https head
+    server["url"] = "https://" + settings.DOMAIN
+    server["description"] = "Service url"
+    openapi_schema["servers"] = []
+    openapi_schema["servers"].append(server)
+
+    # Set language code samples
     openapi_schema = utils.add_examples(openapi_schema)
     app.openapi_schema = openapi_schema
     return app.openapi_schema
@@ -51,6 +61,7 @@ app.openapi = custom_openapi
 
 app.include_router(router, prefix="/status")
 app.include_router(api_router, prefix=settings.API_V1_STR, dependencies=[Security(get_api_key)])
+
 
 @app.on_event("startup")
 async def startup():

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -30,7 +30,13 @@ spec:
       containers:
       - env:
         - name: DOMAIN
+          {{- if .Values.openshift.enabled }}
+          {{- with (index .Values.openshift.hosts 0) }}
+          value: {{ . | quote }}
+          {{- end }}
+          {{- else }}
           value: localhost
+          {{- end }}
         - name: PORT
           value: {{ .Values.httpPort | quote }}
         - name: MAX_WORKERS


### PR DESCRIPTION
Add servers schema in openapi and set openshift host in Helm chart
as domain name.

The servers value will be used by the snippet-enricher-cli to
generate the code samples with the host name.

This fixes issue:
https://github.com/waynesun09/notify-service/issues/15

Signed-off-by: Wayne Sun <gsun@redhat.com>