### PR TITLE
Fix CORS server domain list

### DIFF
--- a/.env
+++ b/.env
@@ -1,10 +1,13 @@
 DOMAIN=localhost
-# DOMAIN=local.dockertoolbox.tiangolo.com
-# DOMAIN=localhost.tiangolo.com
+PORT=8080
+# Target value is for identify the deploy target, could be 'local' or 'openshift', it helps format the openapi server url.
+# Set the value as 'local' if you are testing or deploy on localhost
+TARGET=local
+SSL_ENABLED=false
 # DOMAIN=dev.notify-service.com
 
 # Backend
-BACKEND_CORS_ORIGINS=["http://localhost", "http://localhost:4200", "http://localhost:3000", "http://localhost:8080", "https://localhost", "https://localhost:4200", "https://localhost:3000", "https://localhost:8080", "http://dev.notify-service.com", "https://stag.notify-service.com", "https://notify-service.com", "http://local.dockertoolbox.tiangolo.com", "http://localhost.tiangolo.com"]
+BACKEND_CORS_ORIGINS=["http://localhost", "http://localhost:8080", "https://localhost", "https://localhost:4200", "https://localhost:8080", "http://dev.notify-service.com", "https://stag.notify-service.com", "https://notify-service.com"]
 PROJECT_NAME=notify-service
 SECRET_KEY=
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -7,6 +7,11 @@ from pydantic import AnyHttpUrl, BaseSettings, EmailStr, HttpUrl, validator, Red
 
 class Settings(BaseSettings):
     DOMAIN: str
+    PORT: str
+    # Default deploy target is openshift
+    TARGET: str = "openshift"
+    # Default ssl is enabled with openshift route tls termination set as edge
+    SSL_ENABLED: bool = True
     API_V1_STR: str = "/api/v1"
     SECRET_KEY: str = secrets.token_urlsafe(32)
     # 60 minutes * 24 hours * 8 days = 8 days

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -24,7 +24,7 @@
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- else if .Values.openshift.enabled }}
 {{- range $host := .Values.openshift.hosts }}
-  export HTTP_URL=https://{{ $host }}:{{ $.Values.httpPort }}
+  export HTTP_URL=https://{{ $host }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
The CORS require server host url explicitly set, also the port need
be included.

For local deployment, the port need be added to the server url,
while with DEFAULT openshift edge tls termination, the port should
not be added.

So add new TARGET and SSL_ENABLED parameters to identify the
deploy target env and tls status, and update the server list
accordingly.

By default with Helm chart deploy, the value with TARGET and
TLS_ENABLED don't need be set in the Helm chart as default in the
app/core/config.py are set with:

  TARGET: openshift
  TLS_ENABLED: true

Signed-off-by: Wayne Sun <gsun@redhat.com>